### PR TITLE
Make Wiremock compatible with protocols supported by Apache Camel

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ WireMock - a web service test double for all occasions
 Key Features
 ------------
 	
--	HTTP response stubbing, matchable on URL, header and body content patterns
+-	__objective of this fork:__ compatible with many protocols (uses Apache Camel under the hood)
+-	__objective of this fork:__ response stubbing, with extensible matcher plugins for each protocol (URL, header and body content patterns for HTTP)
 -	Request verification
 -	Runs in unit tests, as a standalone process or as a WAR app
 -	Configurable via a fluent Java API, JSON files and JSON over HTTP

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ version = '2.19.0'
 def shouldPublishLocally = System.getProperty('LOCAL_PUBLISH')
 
 def versions = [
+    camel: '2.23.0',
     handlebars: '4.0.7',
     jackson: '2.8.11',
     jacksonDatabind: '2.8.11.2',
@@ -46,6 +47,7 @@ repositories {
 }
 
 dependencies {
+    compile 'org.apache.camel:camel-core:$versions.camel"
     compile "org.eclipse.jetty:jetty-server:$versions.jetty"
     compile "org.eclipse.jetty:jetty-servlet:$versions.jetty"
     compile "org.eclipse.jetty:jetty-servlets:$versions.jetty"


### PR DESCRIPTION
The main objective is to allow Wiremock to mock any protocol supported by Apache Camel instead of "just" HTTP.

Apache Camel is an implementation of Enterprise Integration Patterns which is a first-class candidate to work with wiremock:
- support many protocols (not just HTTP)
- each protocol (even non-HTTP ones like JMS) is defined internally by a URL, so wiremock's URL pattern matching should work without any change
- the "Smart Router" enterprise integration pattern record the response URL, so it is a good basis to route request to wiremock recorder / mocker